### PR TITLE
Bump version to 4, update dependencies and tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,10 @@
 {
   "node": true,
   "browser": true,
-  "predef": ["describe", "it", "before"]
+  "predef": [
+    "describe",
+    "it",
+    "before"
+  ],
+  "esversion": 9
 }

--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -11,7 +11,7 @@ const httpsAgent = new https.Agent({
 	keepAlive: true
 });
 
-const agent = function(_parsedURL) {
+const agent = function (_parsedURL) {
 	if (_parsedURL.protocol == 'http:') {
 		return httpAgent;
 	} else {
@@ -19,11 +19,11 @@ const agent = function(_parsedURL) {
 	}
 };
 
-module.exports = function(url, options) {
+module.exports = function (url, options) {
 	if (/^\/\//.test(url)) {
 		url = 'https:' + url;
 	}
-	return realFetch.call(this, url, {agent, ...options});
+	return realFetch.call(this, url, { agent, ...options });
 };
 
 if (!global.fetch) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svix-fetch",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "An isomorphic WHATWG Fetch API, for Node & Browserify with keepalives",
   "browser": "fetch-npm-browserify.js",
   "main": "fetch-npm-node.js",
@@ -26,10 +26,15 @@
     "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^5.2.0",
     "jshint": "^2.5.11",
-    "lintspaces-cli": "^0.7.1",
-    "mocha": "^8.1.3",
-    "nock": "^13.0.4"
+    "lintspaces-cli": "^1.0.0",
+    "mocha": "^11.1.0",
+    "nock": "^14.0.4"
+  },
+  "overrides": {
+    "node-fetch": {
+      "whatwg-url": "14.2.0"
+    }
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -12,9 +12,9 @@ function responseToText(response) {
 	return response.text();
 }
 
-describe('fetch', function() {
+describe('fetch', function () {
 
-	before(function() {
+	before(function () {
 		nock('https://mattandre.ws')
 			.get('/succeed.txt')
 			.reply(200, good);
@@ -23,24 +23,24 @@ describe('fetch', function() {
 			.reply(404, bad);
 	});
 
-	it('should be defined', function() {
+	it('should be defined', function () {
 		expect(fetch).to.be.a('function');
 	});
 
-	it('should facilitate the making of requests', function(done) {
-		fetch('//mattandre.ws/succeed.txt')
+	it('should facilitate the making of requests', function (done) {
+		fetch('https://mattandre.ws/succeed.txt')
 			.then(responseToText)
-			.then(function(data) {
+			.then(function (data) {
 				expect(data).to.equal(good);
 				done();
 			})
 			.catch(done);
 	});
 
-	it('should do the right thing with bad requests', function(done) {
-		fetch('//mattandre.ws/fail.txt')
+	it('should do the right thing with bad requests', function (done) {
+		fetch('https://mattandre.ws/fail.txt')
 			.then(responseToText)
-			.catch(function(err) {
+			.catch(function (err) {
 				expect(err.toString()).to.equal("Error: Bad server response");
 				done();
 			})


### PR DESCRIPTION
Should solve See https://github.com/svix/svix-webhooks/issues/1447

This forces `svix-fetch` to use a newer version of `whatwg-url`, which doesn't have the `punycode` deprecation warning. 